### PR TITLE
Added a set of key-values pairs to SSEClient

### DIFF
--- a/Lib.AspNetCore.ServerSentEvents/IServerSentEventsClient.cs
+++ b/Lib.AspNetCore.ServerSentEvents/IServerSentEventsClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Security.Claims;
@@ -25,6 +26,11 @@ namespace Lib.AspNetCore.ServerSentEvents
         /// Gets the value indicating if client is connected.
         /// </summary>
         bool IsConnected { get; }
+
+        /// <summary>
+        /// A set of key-values pairs to store pieces of information that can be used to select clients when sending events.
+        /// </summary>
+        IDictionary<string, string> Properties { get; }
         #endregion
 
         #region Methods

--- a/Lib.AspNetCore.ServerSentEvents/ServerSentEventsClient.cs
+++ b/Lib.AspNetCore.ServerSentEvents/ServerSentEventsClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Security.Claims;
@@ -30,6 +31,11 @@ namespace Lib.AspNetCore.ServerSentEvents.Internals
         /// Gets the value indicating if client is connected.
         /// </summary>
         public bool IsConnected { get; internal set; }
+
+        /// <summary>
+        /// A set of key-values pairs to store pieces of information that can be used to select clients when sending events.
+        /// </summary>
+        public IDictionary<string, string> Properties { get; } = new Dictionary<string, string>();
         #endregion
 
         #region Constructor


### PR DESCRIPTION
Added a set of key-values pairs to store pieces of information that can be used to select clients when sending events.