### PR TITLE
Changed client properties to concurrent dictionary  and added extension  methods to copy request headers into client properties.

### DIFF
--- a/Lib.AspNetCore.ServerSentEvents/Extensions/ServerSentEventsClientConnectedArgsExtensions.cs
+++ b/Lib.AspNetCore.ServerSentEvents/Extensions/ServerSentEventsClientConnectedArgsExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace Lib.AspNetCore.ServerSentEvents.Extensions
@@ -20,9 +19,9 @@ namespace Lib.AspNetCore.ServerSentEvents.Extensions
             if (!args.Request.Headers.ContainsKey(header))
                 return;
 
-            if (overwrite && args.Client.Properties.ContainsKey(header))
+            if (overwrite)
             {
-                args.Client.Properties[header] = args.Request.Headers[header];
+                args.Client.Properties.AddOrUpdate(header, args.Request.Headers[header], (k, v) => args.Request.Headers[k]);
                 return;
             }
 
@@ -41,11 +40,12 @@ namespace Lib.AspNetCore.ServerSentEvents.Extensions
             {
                 if (overwrite && args.Client.Properties.ContainsKey(header.Key))
                 {
-                    args.Client.Properties[header.Key] = header.Value;
+                    args.Client.Properties.AddOrUpdate(header.Key, header.Value, (k, v) => header.Value);
                     continue;
                 }
 
                 args.Client.Properties.TryAdd(header.Key, header.Value);
+
             }
         }
     }

--- a/Lib.AspNetCore.ServerSentEvents/Extensions/ServerSentEventsClientConnectedArgsExtensions.cs
+++ b/Lib.AspNetCore.ServerSentEvents/Extensions/ServerSentEventsClientConnectedArgsExtensions.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Lib.AspNetCore.ServerSentEvents.Extensions
+{
+    /// <summary>
+    /// Extension methods utility class that simplifies operations on the client at connection time 
+    /// </summary>
+    public static class ServerSentEventsClientConnectedArgsExtensions
+    {
+        /// <summary>
+        /// Add a property to the client from the specified header in the request object.
+        /// </summary>
+        /// <param name="args">The client connected args object that contains reference to both the client and the request object.</param>
+        /// <param name="header">The name of the request header that contains the property value to add to the client. The property name will be equal to the header name.</param>
+        /// <param name="overwrite">If true the value of the existing property will be updated. If false the current value of the existing property will be retained.</param>
+        public static void AddPropertyToClientFromHeader(this ServerSentEventsClientConnectedArgs args, string header, bool overwrite = false)
+        {
+            if (!args.Request.Headers.ContainsKey(header))
+                return;
+
+            if (overwrite && args.Client.Properties.ContainsKey(header))
+            {
+                args.Client.Properties[header] = args.Request.Headers[header];
+                return;
+            }
+
+            args.Client.Properties.TryAdd(header, args.Request.Headers[header]);
+        }
+
+        /// <summary>
+        /// Add a set of properties to the client from the headers in the request object whose name matches the specified regular expression.
+        /// </summary>
+        /// <param name="args">The client connected args object that contains reference to both the client and the request object.</param>
+        /// <param name="headerSelectorRegEx">The regular expression used to select the headers in the request object.</param>
+        /// <param name="overwrite">If true the value of any existing property will be updated. If false the current value of any existing property will be retained.</param>
+        public static void AddPropertiesToClientFromHeaders(this ServerSentEventsClientConnectedArgs args, Regex headerSelectorRegEx, bool overwrite = false)
+        {
+            foreach (var header in args.Request.Headers.Where(h => headerSelectorRegEx.IsMatch(h.Key)))
+            {
+                if (overwrite && args.Client.Properties.ContainsKey(header.Key))
+                {
+                    args.Client.Properties[header.Key] = header.Value;
+                    continue;
+                }
+
+                args.Client.Properties.TryAdd(header.Key, header.Value);
+            }
+        }
+    }
+}

--- a/Lib.AspNetCore.ServerSentEvents/IServerSentEventsClient.cs
+++ b/Lib.AspNetCore.ServerSentEvents/IServerSentEventsClient.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Security.Claims;

--- a/Lib.AspNetCore.ServerSentEvents/IServerSentEventsClient.cs
+++ b/Lib.AspNetCore.ServerSentEvents/IServerSentEventsClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -30,7 +31,7 @@ namespace Lib.AspNetCore.ServerSentEvents
         /// <summary>
         /// A set of key-values pairs to store pieces of information that can be used to select clients when sending events.
         /// </summary>
-        IDictionary<string, string> Properties { get; }
+        ConcurrentDictionary<string, string> Properties { get; }
         #endregion
 
         #region Methods

--- a/Lib.AspNetCore.ServerSentEvents/Lib.AspNetCore.ServerSentEvents.csproj
+++ b/Lib.AspNetCore.ServerSentEvents/Lib.AspNetCore.ServerSentEvents.csproj
@@ -33,4 +33,9 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Test.AspNetCore.ServerSentEvents</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/Lib.AspNetCore.ServerSentEvents/ServerSentEventsClient.cs
+++ b/Lib.AspNetCore.ServerSentEvents/ServerSentEventsClient.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Security.Claims;
@@ -35,7 +35,7 @@ namespace Lib.AspNetCore.ServerSentEvents.Internals
         /// <summary>
         /// A set of key-values pairs to store pieces of information that can be used to select clients when sending events.
         /// </summary>
-        public IDictionary<string, string> Properties { get; } = new Dictionary<string, string>();
+        public ConcurrentDictionary<string, string> Properties { get; } = new ConcurrentDictionary<string, string>();
         #endregion
 
         #region Constructor

--- a/Test.AspNetCore.ServerSentEvents/Extensions/ServerSentEventsClientConnectedArgsExtensionsTests.cs
+++ b/Test.AspNetCore.ServerSentEvents/Extensions/ServerSentEventsClientConnectedArgsExtensionsTests.cs
@@ -1,0 +1,267 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Security.Claims;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Lib.AspNetCore.ServerSentEvents;
+using Lib.AspNetCore.ServerSentEvents.Extensions;
+using Lib.AspNetCore.ServerSentEvents.Internals;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Primitives;
+using Moq;
+using Xunit;
+
+namespace Test.AspNetCore.ServerSentEvents.Extensions
+{
+    public class ServerSentEventsClientConnectedArgsExtensionsTests
+    {
+        #region Fields
+        private const string HEADER_1_KEY = "header-1";
+        private const string HEADER_1_VALUE = "value-1";
+        private const string HEADER_2_A_KEY = "header-2a";
+        private const string HEADER_2_A_VALUE = "value-2a";
+        private const string HEADER_2_B_KEY = "header-2b";
+        private const string HEADER_2_B_VALUE = "value-2b";
+        private const string HEADER_3_KEY = "header-3";
+        private const string HEADER_3_VALUE = "value-3";
+        #endregion
+
+        #region Prepare SUT
+        private static ServerSentEventsClientConnectedArgs PrepareServerSentEventsClientConnectedArgs(IDictionary<string, StringValues> headers, IDictionary<string, string> properties)
+        {
+            return new ServerSentEventsClientConnectedArgs(
+                PrepareHttpRequest(headers),
+                PrepareClient(properties)
+                );
+        }
+
+        private static HttpRequest PrepareHttpRequest(IDictionary<string, StringValues> headers)
+        {
+            var context = new DefaultHttpContext();
+
+            foreach (var header in headers)
+            {
+                context.Request.Headers.Add(header);
+            }
+
+            return context.Request;
+        }
+
+        private static IServerSentEventsClient PrepareClient(IDictionary<string, string> properties)
+        {
+            var context = new DefaultHttpContext();
+
+            var client = new ServerSentEventsClient(Guid.Empty, new ClaimsPrincipal(), context.Response);
+
+            foreach (var property in properties)
+            {
+                client.Properties.TryAdd(property.Key, property.Value);
+            }
+
+            return client;
+        }
+        #endregion
+
+        #region Tests
+        [Fact]
+        public void AddPropertyToClientFromHeader_ShouldAddProperty_WhenItDoesNotExist()
+        {
+            // ARRANGE
+            var headers = new Dictionary<string, StringValues>
+                          {
+                              {
+                                  HEADER_2_A_KEY, HEADER_2_A_VALUE
+                              },
+                              {
+                                  HEADER_2_B_KEY, HEADER_2_B_VALUE
+                              },
+                          };
+
+            var clientProperties = new Dictionary<string, string>
+                                   {
+                                       {
+                                           HEADER_1_KEY, HEADER_1_VALUE
+                                       }
+                                   };
+
+            var args = PrepareServerSentEventsClientConnectedArgs(headers, clientProperties);
+
+            // ACT
+            args.AddPropertyToClientFromHeader(HEADER_2_A_KEY);
+
+            //ASSERT
+            Assert.Contains(new KeyValuePair<string,string>(HEADER_2_A_KEY, HEADER_2_A_VALUE), args.Client.Properties);
+        }
+
+        [Fact]
+        public void AddPropertyToClientFromHeader_ShouldUpdateProperty_WhenInstructedToOverwrite()
+        {
+            // ARRANGE
+            var headers = new Dictionary<string, StringValues>
+                          {
+                              {
+                                  HEADER_1_KEY, HEADER_2_A_VALUE
+                              }
+                          };
+
+            var clientProperties = new Dictionary<string, string>
+                                   {
+                                       {
+                                           HEADER_1_KEY, HEADER_1_VALUE
+                                       }
+                                   };
+
+            var args = PrepareServerSentEventsClientConnectedArgs(headers, clientProperties);
+
+            // ACT
+            args.AddPropertyToClientFromHeader(HEADER_1_KEY, true);
+
+            //ASSERT
+            Assert.Contains(new KeyValuePair<string, string>(HEADER_1_KEY, HEADER_2_A_VALUE), args.Client.Properties);
+        }
+
+        [Fact]
+        public void AddPropertyToClientFromHeader_ShouldNotUpdateProperty_WhenNotInstructedToOverwrite()
+        {
+            // ARRANGE
+            var headers = new Dictionary<string, StringValues>
+                          {
+                              {
+                                  HEADER_1_KEY, HEADER_2_A_VALUE
+                              }
+                          };
+
+            var clientProperties = new Dictionary<string, string>
+                                   {
+                                       {
+                                           HEADER_1_KEY, HEADER_1_VALUE
+                                       }
+                                   };
+
+            var args = PrepareServerSentEventsClientConnectedArgs(headers, clientProperties);
+
+            // ACT
+            args.AddPropertyToClientFromHeader(HEADER_1_KEY, false);
+
+            //ASSERT
+            Assert.Contains(new KeyValuePair<string, string>(HEADER_1_KEY, HEADER_1_VALUE), args.Client.Properties);
+        }
+
+        [Fact]
+        public void AddPropertiesToClientFromHeaders_ShouldAddProperty_WhenItDoesNotExist()
+        {
+            // ARRANGE
+            var headers = new Dictionary<string, StringValues>
+                          {
+                              {
+                                  HEADER_2_A_KEY, HEADER_2_A_VALUE
+                              },
+                              {
+                                  HEADER_2_B_KEY, HEADER_2_B_VALUE
+                              },
+                              {
+                                  HEADER_3_KEY, HEADER_3_VALUE
+                              },
+                          };
+
+            var clientProperties = new Dictionary<string, string>
+                                   {
+                                       {
+                                           HEADER_1_KEY, HEADER_1_VALUE
+                                       }
+                                   };
+
+            var args = PrepareServerSentEventsClientConnectedArgs(headers, clientProperties);
+
+            // ACT
+            args.AddPropertiesToClientFromHeaders(new Regex(@"header-2\.*"));
+
+            //ASSERT
+            Assert.Contains(new KeyValuePair<string, string>(HEADER_2_A_KEY, HEADER_2_A_VALUE), args.Client.Properties);
+            Assert.Contains(new KeyValuePair<string, string>(HEADER_2_B_KEY, HEADER_2_B_VALUE), args.Client.Properties);
+            Assert.DoesNotContain(new KeyValuePair<string, string>(HEADER_3_KEY, HEADER_3_VALUE), args.Client.Properties);
+        }
+
+        [Fact]
+        public void AddPropertiesToClientFromHeaders_ShouldUpdateProperty_WhenInstructedToOverwrite()
+        {
+            // ARRANGE
+            var headers = new Dictionary<string, StringValues>
+                          {
+                              {
+                                  HEADER_2_A_KEY, HEADER_2_A_VALUE
+                              },
+                              {
+                                  HEADER_2_B_KEY, HEADER_2_B_VALUE
+                              },
+                              {
+                                  HEADER_3_KEY, HEADER_3_VALUE
+                              },
+                          };
+
+            var clientProperties = new Dictionary<string, string>
+                                   {
+                                       {
+                                           HEADER_1_KEY, HEADER_1_VALUE
+                                       },
+                                       {
+                                           HEADER_2_A_KEY, HEADER_2_B_VALUE
+                                       },
+                                   };
+
+            var args = PrepareServerSentEventsClientConnectedArgs(headers, clientProperties);
+
+            // ACT
+            args.AddPropertiesToClientFromHeaders(new Regex(@"header-2\.*"), true);
+
+            //ASSERT
+            Assert.Contains(new KeyValuePair<string, string>(HEADER_2_A_KEY, HEADER_2_A_VALUE), args.Client.Properties);
+            Assert.Contains(new KeyValuePair<string, string>(HEADER_2_B_KEY, HEADER_2_B_VALUE), args.Client.Properties);
+            Assert.DoesNotContain(new KeyValuePair<string, string>(HEADER_3_KEY, HEADER_3_VALUE), args.Client.Properties);
+        }
+
+        [Fact]
+        public void AddPropertiesToClientFromHeaders_ShouldNotUpdateProperty_WhenNotInstructedToOverwrite()
+        {
+            // ARRANGE
+            var headers = new Dictionary<string, StringValues>
+                          {
+                              {
+                                  HEADER_2_A_KEY, HEADER_2_A_VALUE
+                              },
+                              {
+                                  HEADER_2_B_KEY, HEADER_2_B_VALUE
+                              },
+                              {
+                                  HEADER_3_KEY, HEADER_3_VALUE
+                              },
+                          };
+
+            var clientProperties = new Dictionary<string, string>
+                                   {
+                                       {
+                                           HEADER_1_KEY, HEADER_1_VALUE
+                                       },
+                                       {
+                                           HEADER_2_A_KEY, HEADER_2_B_VALUE
+                                       },
+                                   };
+
+            var args = PrepareServerSentEventsClientConnectedArgs(headers, clientProperties);
+
+            // ACT
+            args.AddPropertiesToClientFromHeaders(new Regex(@"header-2\.*"), false);
+
+            //ASSERT
+            Assert.Contains(new KeyValuePair<string, string>(HEADER_2_A_KEY, HEADER_2_B_VALUE), args.Client.Properties);
+            Assert.Contains(new KeyValuePair<string, string>(HEADER_2_B_KEY, HEADER_2_B_VALUE), args.Client.Properties);
+            Assert.DoesNotContain(new KeyValuePair<string, string>(HEADER_3_KEY, HEADER_3_VALUE), args.Client.Properties);
+        }
+
+        #endregion
+    }
+}

--- a/Test.AspNetCore.ServerSentEvents/Extensions/ServerSentEventsClientConnectedArgsExtensionsTests.cs
+++ b/Test.AspNetCore.ServerSentEvents/Extensions/ServerSentEventsClientConnectedArgsExtensionsTests.cs
@@ -1,18 +1,12 @@
 ﻿using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Security.Claims;
 using System.Text.RegularExpressions;
-using System.Threading;
-using System.Threading.Tasks;
 using Lib.AspNetCore.ServerSentEvents;
 using Lib.AspNetCore.ServerSentEvents.Extensions;
 using Lib.AspNetCore.ServerSentEvents.Internals;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
-using Moq;
 using Xunit;
 
 namespace Test.AspNetCore.ServerSentEvents.Extensions

--- a/Test.AspNetCore.ServerSentEvents/Middleware/HandshakeTests.cs
+++ b/Test.AspNetCore.ServerSentEvents/Middleware/HandshakeTests.cs
@@ -10,7 +10,7 @@ using Lib.AspNetCore.ServerSentEvents;
 
 namespace Test.AspNetCore.ServerSentEvents.Middleware
 {
-    public class HandshakeTests
+    public class ServerSentEventsClientConnectedArgsExtensionsTests
     {
         #region Fields
         private const string ACCEPT_HTTP_HEADER = "Accept";


### PR DESCRIPTION
The client property collection should be a ConcurrentDictionary to safely support properties added by other threads. I also added a couple of extension methods to transfer headers into the client properties collection. Plus unit tests.