### PR TITLE
Made client properties thread safe.

### DIFF
--- a/Lib.AspNetCore.ServerSentEvents/IServerSentEventsClient.cs
+++ b/Lib.AspNetCore.ServerSentEvents/IServerSentEventsClient.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Security.Claims;
@@ -26,11 +25,6 @@ namespace Lib.AspNetCore.ServerSentEvents
         /// Gets the value indicating if client is connected.
         /// </summary>
         bool IsConnected { get; }
-
-        /// <summary>
-        /// A set of key-values pairs to store pieces of information that can be used to select clients when sending events.
-        /// </summary>
-        IDictionary<string, string> Properties { get; }
         #endregion
 
         #region Methods
@@ -63,6 +57,31 @@ namespace Lib.AspNetCore.ServerSentEvents
         /// <param name="cancellationToken">The cancellation token to cancel operation.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
         Task SendEventAsync(ServerSentEvent serverSentEvent, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Retrieves a piece of information associated to this client.
+        /// </summary>
+        /// <typeparam name="T">The type of the property being retrieved.</typeparam>
+        /// <param name="name">The name of the property being retrieved.</param>
+        /// <returns>The value of the property whose name has been specified if it exists in the set of properties associated to the client. Default otherwise.</returns>
+        T GetProperty<T>(string name);
+
+        /// <summary>
+        /// Removes a piece of information associated to this client.
+        /// </summary>
+        /// <typeparam name="T">The type of the property being removed.</typeparam>
+        /// <param name="name">The name of the property being removed.</param>
+        /// <returns>The value of the property whose name has been specified if it exists in the set of properties associated to the client. Default otherwise.</returns>
+        T RemoveProperty<T>(string name);
+
+        /// <summary>
+        /// Adds a property to the client so that it can be used to store client related pieces of information.
+        /// </summary>
+        /// <param name="name">The name of the property being added.</param>
+        /// <param name="value">The value of the property being added.</param>
+        /// <param name="overwrite">When true and the property already exists, its value will be updated. When false and the property already exists, its value will not be updated.</param>
+        /// <returns>True if the property has been added or updated, false otherwise.</returns>
+        bool SetProperty(string name, object value, bool overwrite = false);
         #endregion
     }
 }

--- a/Lib.AspNetCore.ServerSentEvents/Lib.AspNetCore.ServerSentEvents.csproj
+++ b/Lib.AspNetCore.ServerSentEvents/Lib.AspNetCore.ServerSentEvents.csproj
@@ -33,4 +33,9 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Test.AspNetCore.ServerSentEvents</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/Test.AspNetCore.ServerSentEvents/AuthorizationTests.cs
+++ b/Test.AspNetCore.ServerSentEvents/AuthorizationTests.cs
@@ -1,0 +1,137 @@
+﻿using System;
+using System.Security.Claims;
+using Lib.AspNetCore.ServerSentEvents.Internals;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Test.AspNetCore.ServerSentEvents
+{
+    public class ServerSentEventsClientTests
+    {
+        #region Fields
+        private const string PROPERTY_1_NAME = "property-1";
+        private const string PROPERTY_1_VALUE = "property-1-value";
+        private const string PROPERTY_1_UPDATED_VALUE = "property-1-updated-value";
+        #endregion
+
+        #region Prepare SUT
+        private static ServerSentEventsClient PrepareServerSentEventsClient()
+        {
+            var context = new DefaultHttpContext();
+            return new ServerSentEventsClient(Guid.NewGuid(), new ClaimsPrincipal(), context.Response);
+        }
+        #endregion
+
+        #region Tests
+        [Fact]
+        public void GetProperty_ReturnsTheStoredValue()
+        {
+            // ARRANGE
+            var client = PrepareServerSentEventsClient();
+
+            client.SetProperty(PROPERTY_1_NAME, PROPERTY_1_VALUE);
+
+            // ACT
+            var expected = client.GetProperty<string>(PROPERTY_1_NAME);
+
+            // ASSERT
+            Assert.Equal(expected, PROPERTY_1_VALUE);
+        }
+
+        [Fact]
+        public void GetProperty_ReturnsDefaultIfPropertyNotPresent()
+        {
+            // ARRANGE
+            var client = PrepareServerSentEventsClient();
+
+            client.SetProperty(PROPERTY_1_NAME, PROPERTY_1_VALUE);
+
+            // ACT
+            var actual = client.GetProperty<string>(PROPERTY_1_UPDATED_VALUE);
+
+            // ASSERT
+            Assert.Equal(default, actual);
+        }
+
+        [Fact]
+        public void RemoveProperty_RemovesTheProperty()
+        {
+            // ARRANGE
+            var client = PrepareServerSentEventsClient();
+
+            client.SetProperty(PROPERTY_1_NAME, PROPERTY_1_VALUE);
+
+            // ACT
+            var actual = client.RemoveProperty<string>(PROPERTY_1_NAME);
+
+            // ASSERT
+            Assert.Equal(PROPERTY_1_VALUE, actual);
+        }
+
+        [Fact]
+        public void RemoveProperty_DoesNotBreakIfPropertyDoesNotExist()
+        {
+            // ARRANGE
+            var client = PrepareServerSentEventsClient();
+
+            // ACT
+            var actual = client.RemoveProperty<string>(PROPERTY_1_NAME);
+
+            // ASSERT
+            Assert.Equal(default, actual);
+        }
+
+        [Fact]
+        public void SetProperty_AddProperty()
+        {
+            // ARRANGE
+            var client = PrepareServerSentEventsClient();
+
+            // ACT
+            var actual = client.SetProperty(PROPERTY_1_NAME, PROPERTY_1_VALUE, true);
+
+            // ASSERT
+            var actualValue = client.GetProperty<string>(PROPERTY_1_NAME);
+
+            Assert.True(actual);
+            Assert.Equal(PROPERTY_1_VALUE, actualValue);
+        }
+
+        [Fact]
+        public void SetProperty_UpdateProperty()
+        {
+            // ARRANGE
+            var client = PrepareServerSentEventsClient();
+
+            client.SetProperty(PROPERTY_1_NAME, PROPERTY_1_VALUE);
+
+            // ACT
+            var actual = client.SetProperty(PROPERTY_1_NAME, PROPERTY_1_UPDATED_VALUE, true);
+
+            // ASSERT
+            var actualValue = client.GetProperty<string>(PROPERTY_1_NAME);
+
+            Assert.True(actual);
+            Assert.Equal(PROPERTY_1_UPDATED_VALUE, actualValue);
+        }
+
+        [Fact]
+        public void SetProperty_DoesNotUpdateProperty()
+        {
+            // ARRANGE
+            var client = PrepareServerSentEventsClient();
+
+            client.SetProperty(PROPERTY_1_NAME, PROPERTY_1_VALUE);
+
+            // ACT
+            var actual = client.SetProperty(PROPERTY_1_NAME, PROPERTY_1_UPDATED_VALUE);
+
+            // ASSERT
+            var actualValue = client.GetProperty<string>(PROPERTY_1_NAME);
+
+            Assert.False(actual);
+            Assert.Equal(PROPERTY_1_VALUE, actualValue);
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
Hi Tomasz,

I realised that if the client properties collection is thread safe it can then be more useful in more usage scenarios. This PR removes the Properties dictionary and replaces it with a set of 3 methods (SetProperty, GetProperty and RemoveProperty) backed up by a ConcurrentDictionary.
The ConcurrentDictionary can now store objects rather then just strings, again to increase its usefulness in more usage scenarios. Therefore, the before mentioned methods are implemented as generics to enforce type checking.

Unfortunately this is a breaking change.

Best regards,

Sebastiano