### PR TITLE
Proposed way of solving #49

### DIFF
--- a/Lib.AspNetCore.ServerSentEvents/IServerSentEventsClient.cs
+++ b/Lib.AspNetCore.ServerSentEvents/IServerSentEventsClient.cs
@@ -37,6 +37,11 @@ namespace Lib.AspNetCore.ServerSentEvents
         void Disconnect();
 
         /// <summary>
+        /// Disconnects the currently connected request only.
+        /// </summary>
+        void DisconnectCurrentRequest();
+
+        /// <summary>
         /// Sends event to client.
         /// </summary>
         /// <param name="text">The simple text event.</param>

--- a/Lib.AspNetCore.ServerSentEvents/IServerSentEventsService.cs
+++ b/Lib.AspNetCore.ServerSentEvents/IServerSentEventsService.cs
@@ -28,6 +28,14 @@ namespace Lib.AspNetCore.ServerSentEvents
         /// Gets the interval after which clients will attempt to reestablish failed connections.
         /// </summary>
         uint? ReconnectInterval { get; }
+
+        /// <summary>
+        /// Gets the callback that will be used to validate an incoming connection.
+        /// </summary>
+        /// <remarks>
+        /// If the callback handled the request, <c>false</c> is returned and the protocol will not be started.
+        /// </remarks>
+        Func<ServerSentEventsClientValidationArgs, Task<bool>> ValidationHandler { get; }
         #endregion
 
         #region Methods
@@ -234,6 +242,16 @@ namespace Lib.AspNetCore.ServerSentEvents
         /// <param name="client">The client who is disconnecting.</param>
         /// <returns>The task object representing the asynchronous operation.</returns>
         Task OnDisconnectAsync(HttpRequest request, IServerSentEventsClient client);
+
+        /// <summary>
+        /// Method which is called to validate a connection. The base implementation calls the <see cref="ValidationHandler"/> callback.
+        /// </summary>
+        /// <param name="request">The request which has been made in order to establish the connection.</param>
+        /// <param name="response">The response, if necessary to handle the request.</param>
+        /// <param name="lastEventId">The identifier of last event which client has received.</param>
+        /// <returns>The task object representing the outcome of the validation. If the validation succeeded, the connection will continue, otherwise the validation is assumed to have handled the request.</returns>
+        Task<bool> OnValidateConnectionAsync(HttpRequest request, HttpResponse response, string lastEventId);
+
         #endregion
     }
 }

--- a/Lib.AspNetCore.ServerSentEvents/ServerSentEventsClient.cs
+++ b/Lib.AspNetCore.ServerSentEvents/ServerSentEventsClient.cs
@@ -105,6 +105,18 @@ namespace Lib.AspNetCore.ServerSentEvents.Internals
         }
 
         /// <summary>
+        /// Disconnects the currently connected request only.
+        /// </summary>
+        public void DisconnectCurrentRequest()
+        {
+            if (IsConnected) {
+                IsConnected = false;
+                _response.HttpContext.Abort();
+            }
+        }
+
+
+        /// <summary>
         /// Sends event to client.
         /// </summary>
         /// <param name="text">The simple text event.</param>

--- a/Lib.AspNetCore.ServerSentEvents/ServerSentEventsClientValidationArgs.cs
+++ b/Lib.AspNetCore.ServerSentEvents/ServerSentEventsClientValidationArgs.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.AspNetCore.Http;
+
+namespace Lib.AspNetCore.ServerSentEvents
+{
+    /// <summary>
+    /// Provides data for the <see cref="IServerSentEventsService.ValidationHandler"/> event.
+    /// </summary>
+    public struct ServerSentEventsClientValidationArgs
+    {
+        #region Properties
+        /// <summary>
+        /// Gets the request which has been made in order to establish the connection.
+        /// </summary>
+        public HttpRequest Request { get; }
+
+
+        /// <summary>
+        /// Gets the response, if necessary to handle the request.
+        /// </summary>
+        public HttpResponse Response { get; }
+
+        /// <summary>
+        /// Gets the identifier of last event which client has received (available if client has reconnected).
+        /// </summary>
+        public string LastEventId { get; }
+        #endregion
+
+        #region Constructor
+        /// <summary>
+        /// Initializes new instance of data.
+        /// </summary>
+        /// <param name="request">The request which has been made in order to establish the connection.</param>
+        public ServerSentEventsClientValidationArgs(HttpRequest request, HttpResponse response)
+            : this()
+        {
+            Request = request;
+            Response = response;
+            LastEventId = null;
+        }
+
+        /// <summary>
+        /// Initializes new instance of data.
+        /// </summary>
+        /// <param name="request">The request which has been made in order to establish the connection.</param>
+        /// <param name="response">The response, if necessary to handle the request.</param>
+        /// <param name="lastEventId">The identifier of last event which client has received.</param>
+        public ServerSentEventsClientValidationArgs(HttpRequest request, HttpResponse response, string lastEventId)
+            : this()
+        {
+            Request = request;
+            Response = response;
+            LastEventId = lastEventId;
+        }
+        #endregion
+    }
+}

--- a/Lib.AspNetCore.ServerSentEvents/ServerSentEventsMiddleware.cs
+++ b/Lib.AspNetCore.ServerSentEvents/ServerSentEventsMiddleware.cs
@@ -76,6 +76,13 @@ namespace Lib.AspNetCore.ServerSentEvents
                 {
                     return;
                 }
+                
+                string lastEventId = context.Request.Headers[Constants.LAST_EVENT_ID_HTTP_HEADER];
+                var isValid = await _serverSentEventsService.OnValidateConnectionAsync(context.Request, context.Response, lastEventId);
+                if (!isValid)
+                {
+                    return;
+                }
 
                 Guid clientId = _serverSentEventsClientIdProvider.AcquireClientId(context);
                 if (_serverSentEventsService.IsClientConnected(clientId))

--- a/Lib.AspNetCore.ServerSentEvents/ServerSentEventsServiceOptions.cs
+++ b/Lib.AspNetCore.ServerSentEvents/ServerSentEventsServiceOptions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace Lib.AspNetCore.ServerSentEvents
 {
@@ -50,5 +51,12 @@ namespace Lib.AspNetCore.ServerSentEvents
         /// Called when client has disconnected.
         /// </summary>
         public Action<IServerSentEventsService, ServerSentEventsClientDisconnectedArgs> OnClientDisconnected { get; set; }
+
+        /// <summary>
+        /// Called to validate clients.
+        /// This can be used to inspect query string parameters and similar and to return other HTTP responses instead
+        /// of accepting the SSE connection.
+        /// </summary>
+        public Func<ServerSentEventsClientValidationArgs, Task<bool>> ValidationHandler { get; set; }
     }
 }

--- a/Test.AspNetCore.ServerSentEvents/Middleware/Infrastructure/SubjectUnderTestHelper.cs
+++ b/Test.AspNetCore.ServerSentEvents/Middleware/Infrastructure/SubjectUnderTestHelper.cs
@@ -27,7 +27,8 @@ namespace Test.AspNetCore.ServerSentEvents.Middleware.Infrastructure
             IServerSentEventsClientIdProvider serverSentEventsClientIdProvider = null,
             IServerSentEventsNoReconnectClientsIdsStore serverSentEventsNoReconnectClientsIdsStore = null,
             ServerSentEventsService serverSentEventsService = null,
-            ServerSentEventsOptions options = null)
+            ServerSentEventsOptions options = null,
+            bool validateConnectionResult = true)
         {
             return new ServerSentEventsMiddleware<ServerSentEventsService>
             (
@@ -35,7 +36,7 @@ namespace Test.AspNetCore.ServerSentEvents.Middleware.Infrastructure
                 authorizationPolicyProvider ?? Mock.Of<IAuthorizationPolicyProvider>(),
                 serverSentEventsClientIdProvider ?? new NewGuidServerSentEventsClientIdProvider(),
                 serverSentEventsNoReconnectClientsIdsStore ?? new NoOpServerSentEventsNoReconnectClientsIdsStore(),
-                serverSentEventsService ?? Mock.Of<TestServerSentEventsService>(),
+                serverSentEventsService ?? Mock.Of<TestServerSentEventsService>(s => s.OnValidateConnectionAsync(It.IsAny<HttpRequest>(), It.IsAny<HttpResponse>(), It.IsAny<string>()).Result == validateConnectionResult),
                 Options.Create(options ?? new ServerSentEventsOptions()),
                 NullLoggerFactory.Instance
             );

--- a/Test.AspNetCore.ServerSentEvents/Middleware/ValidationTests.cs
+++ b/Test.AspNetCore.ServerSentEvents/Middleware/ValidationTests.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Policy;
+using Moq;
+using Xunit;
+using Lib.AspNetCore.ServerSentEvents;
+using Test.AspNetCore.ServerSentEvents.Middleware.Infrastructure;
+
+namespace Test.AspNetCore.ServerSentEvents.Middleware
+{
+    public class ValidationTests
+    {
+        #region Fields
+        private const string ACCEPT_HTTP_HEADER = "Accept";
+        private const string SSE_CONTENT_TYPE = "text/event-stream";
+
+        private static readonly RequestDelegate NOOP_REQUEST_DELEGATE = (context) => Task.CompletedTask;
+        private static readonly AuthorizationPolicy DEFAULT_AUTHORIZATION_POLICY = new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build();
+        private static readonly AuthenticateResult DEFAULT_AUTHENTICATE_RESULT = AuthenticateResult.NoResult();
+        private static readonly PolicyAuthorizationResult DEFAULT_POLICY_AUTHORIZATION_RESULT = PolicyAuthorizationResult.Success();
+        #endregion
+
+        #region Prepare SUT
+        private IAuthorizationPolicyProvider PrepareAuthorizationPolicyProvider()
+        {
+            Mock<IAuthorizationPolicyProvider> policyProviderMock = new Mock<IAuthorizationPolicyProvider>();
+            policyProviderMock.Setup(m => m.GetDefaultPolicyAsync()).ReturnsAsync(DEFAULT_AUTHORIZATION_POLICY);
+
+            return policyProviderMock.Object;
+        }
+
+        private Mock<IPolicyEvaluator> PreparePolicyEvaluatorMock(HttpContext context, AuthenticateResult authenticateResult = null, PolicyAuthorizationResult policyAuthorizationResult = null)
+        {
+            authenticateResult = authenticateResult ?? DEFAULT_AUTHENTICATE_RESULT;
+            policyAuthorizationResult = policyAuthorizationResult ?? DEFAULT_POLICY_AUTHORIZATION_RESULT;
+
+            Mock<IPolicyEvaluator> policyEvaluatorMock = new Mock<IPolicyEvaluator>();
+            policyEvaluatorMock.Setup(m => m.AuthenticateAsync(It.IsAny<AuthorizationPolicy>(), context)).ReturnsAsync(authenticateResult);
+            policyEvaluatorMock.Setup(m => m.AuthorizeAsync(It.IsAny<AuthorizationPolicy>(), authenticateResult, context, null)).ReturnsAsync(policyAuthorizationResult);
+
+            return policyEvaluatorMock;
+        }
+        #endregion
+
+        #region Tests
+        [Fact]
+        public async Task Invoke_SseRequest_NoValidation_DoesNotPreventAcceptAsync()
+        {
+            Mock<Action<HttpResponse>> onPrepareAcceptMock = new Mock<Action<HttpResponse>>();
+            ServerSentEventsMiddleware<ServerSentEventsService> serverSentEventsMiddleware = SubjectUnderTestHelper.PrepareServerSentEventsMiddleware(options: new ServerSentEventsOptions {
+                OnPrepareAccept = onPrepareAcceptMock.Object
+            });
+            HttpContext context = SubjectUnderTestHelper.PrepareHttpContext();
+
+            await serverSentEventsMiddleware.Invoke(context, null);
+
+            onPrepareAcceptMock.Verify(m => m(It.IsAny<HttpResponse>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Invoke_SseRequest_Validation_DoesNotPreventAcceptWhenValidationSucceedsAsync()
+        {
+            Mock<Action<HttpResponse>> onPrepareAcceptMock = new Mock<Action<HttpResponse>>();
+            ServerSentEventsMiddleware<ServerSentEventsService> serverSentEventsMiddleware = SubjectUnderTestHelper.PrepareServerSentEventsMiddleware(options: new ServerSentEventsOptions {
+                OnPrepareAccept = onPrepareAcceptMock.Object,
+            }, validateConnectionResult:true);
+            HttpContext context = SubjectUnderTestHelper.PrepareHttpContext();
+
+            await serverSentEventsMiddleware.Invoke(context, null);
+
+            onPrepareAcceptMock.Verify(m => m(It.IsAny<HttpResponse>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task Invoke_SseRequest_Validation_DoesPreventAcceptWhenValidationFailsAsync()
+        {
+            Mock<Action<HttpResponse>> onPrepareAcceptMock = new Mock<Action<HttpResponse>>();
+            ServerSentEventsMiddleware<ServerSentEventsService> serverSentEventsMiddleware = SubjectUnderTestHelper.PrepareServerSentEventsMiddleware(options: new ServerSentEventsOptions {
+                OnPrepareAccept = onPrepareAcceptMock.Object
+            }, validateConnectionResult:false);
+            HttpContext context = SubjectUnderTestHelper.PrepareHttpContext();
+
+            await serverSentEventsMiddleware.Invoke(context, null);
+
+            onPrepareAcceptMock.Verify(m => m(It.IsAny<HttpResponse>()), Times.Never);
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
Adding validation step where the service gets the opportunity to stop the SSE connection and return a regular HTTP response instead, as well as a way to disconnect only the current request.

I don't expect this to be the perfect solution and to be merged directly as is. It's just the first attempt at solving the problem.