### PR TITLE
Add a feature to gracefully disconnect the client

### DIFF
--- a/Lib.AspNetCore.ServerSentEvents/IServerSentEventsClient.cs
+++ b/Lib.AspNetCore.ServerSentEvents/IServerSentEventsClient.cs
@@ -34,7 +34,7 @@ namespace Lib.AspNetCore.ServerSentEvents
         /// <remarks>
         /// This requires registering implementations of <see cref="IServerSentEventsClientIdProvider"/> and <see cref="IServerSentEventsNoReconnectClientsIdsStore"/>.
         /// </remarks>
-        void Disconnect();
+        Task Disconnect();
 
         /// <summary>
         /// Sends event to client.

--- a/Lib.AspNetCore.ServerSentEvents/ServerSentEventsClient.cs
+++ b/Lib.AspNetCore.ServerSentEvents/ServerSentEventsClient.cs
@@ -90,7 +90,7 @@ namespace Lib.AspNetCore.ServerSentEvents.Internals
         /// <remarks>
         /// This requires registering implementations of <see cref="IServerSentEventsClientIdProvider"/> and <see cref="IServerSentEventsNoReconnectClientsIdsStore"/>.
         /// </remarks>
-        public void Disconnect()
+        public async Task Disconnect()
         {
             if (!_clientDisconnectServicesAvailable)
             {
@@ -102,7 +102,12 @@ namespace Lib.AspNetCore.ServerSentEvents.Internals
             if (IsConnected)
             {
                 IsConnected = false;
+                await _response.Body.FlushAsync();
+#if !NET461
+                await _response.CompleteAsync();
+#else
                 _response.HttpContext.Abort();
+#endif
             } 
         }
 

--- a/Test.AspNetCore.ServerSentEvents/Unit/Middleware/DisconnectTests.cs
+++ b/Test.AspNetCore.ServerSentEvents/Unit/Middleware/DisconnectTests.cs
@@ -95,7 +95,7 @@ namespace Test.AspNetCore.ServerSentEvents.Unit.Middleware
 
             Task middlewareInvokeTask = serverSentEventsMiddleware.Invoke(context, null);
 
-            serverSentEventsService.GetClient(CLIENT_ID).Disconnect();
+            await serverSentEventsService.GetClient(CLIENT_ID).Disconnect();
 
             await middlewareInvokeTask;
 
@@ -117,7 +117,7 @@ namespace Test.AspNetCore.ServerSentEvents.Unit.Middleware
 
             Task middlewareInvokeTask = serverSentEventsMiddleware.Invoke(context, null);
 
-            serverSentEventsService.GetClient(CLIENT_ID).Disconnect();
+            await serverSentEventsService.GetClient(CLIENT_ID).Disconnect();
 
             await middlewareInvokeTask;
 

--- a/Test.AspNetCore.ServerSentEvents/Unit/ServerSentEventsClientTests.cs
+++ b/Test.AspNetCore.ServerSentEvents/Unit/ServerSentEventsClientTests.cs
@@ -9,6 +9,8 @@ using Lib.AspNetCore.ServerSentEvents.Internals;
 
 namespace Test.AspNetCore.ServerSentEvents.Unit
 {
+    using System.Threading.Tasks;
+
     public class ServerSentEventsClientTests
     {
         #region Fields
@@ -137,31 +139,31 @@ namespace Test.AspNetCore.ServerSentEvents.Unit
         }
 
         [Fact]
-        public void Disconnect_ClientDisconnectServicesNotAvailable_ThrowsInvalidOperationException()
+        public async Task Disconnect_ClientDisconnectServicesNotAvailable_ThrowsInvalidOperationException()
         {
             // ARRANGE
             var client = PrepareServerSentEventsClient();
 
             // ASSERT
-            InvalidOperationException disconnectException = Assert.Throws<InvalidOperationException>(client.Disconnect);
+            InvalidOperationException disconnectException = await Assert.ThrowsAsync<InvalidOperationException>(async () =>await client.Disconnect());
             Assert.Equal(disconnectException.Message, $"Disconnecting a {nameof(ServerSentEventsClient)} requires registering implementations of {nameof(IServerSentEventsClientIdProvider)} and {nameof(IServerSentEventsNoReconnectClientsIdsStore)}.");
         }
 
         [Fact]
-        public void Disconnect_ClientDisconnectServicesAvailable_PreventsReconnect()
+        public async Task Disconnect_ClientDisconnectServicesAvailable_PreventsReconnect()
         {
             // ARRANGE
             var client = PrepareServerSentEventsClient(clientDisconnectServicesAvailable: true);
 
             // ACT
-            client.Disconnect();
+            await client.Disconnect();
 
             // ASSERT
             Assert.True(client.PreventReconnect);
         }
 
         [Fact]
-        public void Disconnect_ClientDisconnectServicesAvailable_Disconnects()
+        public async Task Disconnect_ClientDisconnectServicesAvailable_Disconnects()
         {
             // ARRANGE
             HttpContext context = new DefaultHttpContext();
@@ -172,7 +174,7 @@ namespace Test.AspNetCore.ServerSentEvents.Unit
             var client = PrepareServerSentEventsClient(context: context, clientDisconnectServicesAvailable: true);
 
             // ACT
-            client.Disconnect();
+            await client.Disconnect();
 
             // ASSERT
             Assert.False(client.IsConnected);


### PR DESCRIPTION
Try to fix #73 , breaking changing for `IServerSentEventsClient.Disconnect` method, it's now async task. 
And still need help for NET461 logic to disconnect client gracefully with `HttpResponse.End`.