### PR TITLE
Make ServerSentEventsClient constructor public

### DIFF
--- a/Lib.AspNetCore.ServerSentEvents/ServerSentEventsClient.cs
+++ b/Lib.AspNetCore.ServerSentEvents/ServerSentEventsClient.cs
@@ -41,7 +41,7 @@ namespace Lib.AspNetCore.ServerSentEvents.Internals
         #endregion
 
         #region Constructor
-        internal ServerSentEventsClient(Guid id, HttpContext context, bool clientDisconnectServicesAvailable)
+        public ServerSentEventsClient(Guid id, HttpContext context, bool clientDisconnectServicesAvailable)
         {
             if (context is null)
             {


### PR DESCRIPTION
Changing the constructor of `ServerSentEventsClient` to `public` allows for complete customization of its construction and return process within a `Controller`. This eliminates the need to rely solely on the simpler dependency injection implementation.

For example: 

```csharp
public class SomeController: Controller
{
    public async Task SomeMethod()
    {
        this.Response.ContentType = "text/event-stream"; // or just MediaTypeNames.Text.EventStream
        var client = new ServerSentEventsClient(Guid.NewGuid(), this.HttpContext, true);
        await client.SendEventAsync("data: {\"key\": \"value\"}");
        await client.DisconnectAsync();
    }
}
```

It becomes much more convenient to control the entire SSE response.